### PR TITLE
[Optimization] Board 조회 시 N+1 문제 해결을 위한 Fetch Join 적용

### DIFF
--- a/backend/src/main/java/com/ssafy/picple/domain/board/repository/BoardRepository.java
+++ b/backend/src/main/java/com/ssafy/picple/domain/board/repository/BoardRepository.java
@@ -41,4 +41,18 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
 	// 특정 유저가 특정 사진 공유한 게시물 찾기
 	Board findByUserIdAndPhotoIdAndIsDeletedFalse(Long userId, Long photoId);
+
+	// fetch join을 적용한 전체 조회 메서드
+    @Query("SELECT DISTINCT b FROM Board b " +
+           "LEFT JOIN FETCH b.photo p " +
+           "LEFT JOIN FETCH b.user u " +
+           "WHERE b.isDeleted = false")
+    Page<Board> findAllWithFetchJoin(Pageable pageable);
+
+    // fetch join을 적용한 닉네임 검색 메서드
+    @Query("SELECT DISTINCT b FROM Board b " +
+           "LEFT JOIN FETCH b.photo p " +
+           "LEFT JOIN FETCH b.user u " +
+           "WHERE b.isDeleted = false AND u.nickname = :nickname")
+    Page<Board> findAllByNicknameWithFetchJoin(@Param("nickname") String nickname, Pageable pageable);
 }

--- a/backend/src/main/java/com/ssafy/picple/domain/board/service/BoardServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/picple/domain/board/service/BoardServiceImpl.java
@@ -39,22 +39,28 @@ public class BoardServiceImpl implements BoardService {
 	@Override
 	public List<BoardDto> findBoards(Long userId, String nickname, Pageable pageable) {
 		if (nickname == null || nickname.isEmpty() || nickname.equals("")) {
-			Page<Board> pageResult = boardRepository.findAll(pageable);
+			// Page<Board> pageResult = boardRepository.findAll(pageable);
+			Page<Board> pageResult = boardRepository.findAllWithFetchJoin(pageable);
+
 			return pageResult.getContent().stream().map(board -> new BoardDto(
 					board.getId(),
 					board.getCreatedAt().toString(),
-					getPhotoUrl(board),
+					// getPhotoUrl(board),
+					board.getPhoto().getPhotoUrl(),
 					isLikedByUser(board, userId),
 					board.getHit()
 			)).collect(Collectors.toList());
 		} else {
-			Page<Board> pageResult = boardRepository.findAllByNickname(nickname, pageable);
+			// Page<Board> pageResult = boardRepository.findAllByNickname(nickname, pageable);
+			Page<Board> pageResult = boardRepository.findAllByNicknameWithFetchJoin(nickname, pageable);
+
 			return pageResult.stream()
 					.filter(board -> !board.isDeleted())
 					.map(board -> new BoardDto(
 							board.getId(),
 							board.getCreatedAt().toString(),
-							getPhotoUrl(board),
+							// getPhotoUrl(board),
+							board.getPhoto().getPhotoUrl(),
 							isLikedByUser(board, userId),
 							board.getHit()
 					))


### PR DESCRIPTION
## 변경 사항
- Board 조회 시 발생하는 N+1 문제 해결을 위해 Fetch Join 적용
- BoardService의 findBoards 메서드에서 불필요한 쿼리 호출 제거

### 주요 변경점
1. Repository에 Fetch Join을 사용하는 메서드 추가
   - findAllWithFetchJoin
   - findAllByNicknameWithFetchJoin

2. Service 로직 최적화
   - getPhotoUrl 메서드 호출 제거
   - Fetch Join으로 이미 로드된 Photo 엔티티 직접 사용

## 성능 개선 효과
- 기존: Board 10개 조회 시 → 21번의 쿼리 실행 (1 + 10 + 10)
  - Board 조회 1회
  - Photo 조회 10회
  - BoardLike 조회 10회
- 개선: Board 10개 조회 시 → 11번의 쿼리 실행 (1 + 10)
  - Board와 Photo 조회 1회
  - BoardLike 조회 10회

## 테스트 항목
- [x] Board 목록 조회 시 N+1 문제 해결 확인
- [x] 닉네임으로 검색 시 정상 동작 확인
- [x] 페이징 처리 정상 동작 확인

## 관련 이슈
- Closes #1

## 확인 사항
1. Fetch Join 사용이 최적인지 검토해보기
2. 페이징 처리와 관련하여 성능 이슈 없는지 테스트해보기